### PR TITLE
Updated field extractions to use sourcetype=syslog

### DIFF
--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -14,7 +14,7 @@
 #
 
 [puppet]
-search = (sourcetype=*puppet* OR source=*/puppet.log*)
+search = (sourcetype=*puppet* OR source=*/puppet.log*) OR ( *puppet* source=/var/log/messages) 
 description = Puppet events.
 
 [puppet_agent]

--- a/default/props.conf
+++ b/default/props.conf
@@ -16,13 +16,8 @@
 [(?::){0}*puppet*]
 REPORT-syslog = syslog-extractions
 SHOULD_LINEMERGE = False
-EXTRACT-puppet-filebucket = (?i)FileBucket .* \{md5\}(?P<filebucket_hash>.*)
-EXTRACT-puppet-resource-changed = changed\s+'(?P<resource_attribute_old>[^']*)'\s+to\s+'(?P<resource_attribute_new>[^']*)'
-EXTRACT-puppet-resource-shouldbe = current_value\s+(?P<resource_attribute_old>[^,]*),\s+should\s+be\s+(?P<resource_attribute_new>[^[:space:]]*)
-EXTRACT-puppet-node = (on\s+node|node\s+for|node\s+cache\s+of|catalog\s+for)\s+(?P<node_fdqn>(?P<node>[\w-]+)\.[\w.-]*)
-EXTRACT-puppet-catalog-run-time = Finished catalog run in (?P<catalog_run_time>\d+(\.\d+)?) seconds
-EXTRACT-puppet-resource = (?:source="|\()(?:Scope\()?(?P<resource>(?:/Stage\[(?P<run_stage>[^]]+)\]/(?P<class>[^/]+))?(?:/(?P<defined_type>[^[]+)\[(?P<defined_instance>[^]]+)\])?/?(?P<resource_type>[^[]+)\[(?P<resource_instance>[^]]+)\](?:/(?P<resource_attribute>[^)"]+))?)(?:"|\)(?:\s+(?P<resource_result>.*)$)?)
-EXTRACT-puppet-resource-basic = (?P<resource>\(/(?P<resource_type>[A-Z][^[]+)\[(?P<resource_instance>[^]]+)\](?:/(?P<resource_attribute>[^)]+))?\))\s+(?P<resource_result>.*)$
-EXTRACT-puppet-resource-node = /Node\[(?P<node>[^]]+)\]/
-EXTRACT-puppet-environment = environment\s+(?P<environment>[^\s:]+)
-EXTRACT-puppet-event-msg = puppet-\w+\[\d+\]:\s+(?:\[cimlog[^]]+\])?\s*(?P<event_msg>.*)
+
+REPORT-puppet = puppet-filebucket, puppet-resource-changed, puppet-resource-shouldbe, puppet-node, puppet-catalog-run-time, puppet-resource, puppet-resource-basic, puppet-resource-node, puppet-environment, puppet-event-msg
+
+[syslog]
+REPORT-puppet = puppet-filebucket, puppet-resource-changed, puppet-resource-shouldbe, puppet-node, puppet-catalog-run-time, puppet-resource, puppet-resource-basic, puppet-resource-node, puppet-environment, puppet-event-msg

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -1,0 +1,29 @@
+[puppet-filebucket]
+REGEX = (?i)FileBucket .* \{md5\}(?P<filebucket_hash>.*)
+
+[puppet-resource-changed] 
+REGEX = changed\s+'(?P<resource_attribute_old>[^']*)'\s+to\s+'(?P<resource_attribute_new>[^']*)'
+
+[puppet-resource-shouldbe]
+REGEX = current_value\s+(?P<resource_attribute_old>[^,]*),\s+should\s+be\s+(?P<resource_attribute_new>[^[:space:]]*)
+
+[puppet-node]
+REGEX = (on\s+node|node\s+for|node\s+cache\s+of|catalog\s+for)\s+(?P<node_fdqn>(?P<node>[\w-]+)\.[\w.-]*)
+
+[puppet-catalog-run-time]
+REGEX = Finished catalog run in (?P<catalog_run_time>\d+(\.\d+)?) seconds
+
+[puppet-resource]
+REGEX = (?:source="|\()(?:Scope\()?(?P<resource>(?:/Stage\[(?P<run_stage>[^]]+)\]/(?P<class>[^/]+))?(?:/(?P<defined_type>[^[]+)\[(?P<defined_instance>[^]]+)\])?/?(?P<resource_type>[^[]+)\[(?P<resource_instance>[^]]+)\](?:/(?P<resource_attribute>[^)"]+))?)(?:"|\)(?:\s+(?P<resource_result>.*)$)?)
+
+[puppet-resource-basic]
+REGEX = (?P<resource>\(/(?P<resource_type>[A-Z][^[]+)\[(?P<resource_instance>[^]]+)\](?:/(?P<resource_attribute>[^)]+))?\))\s+(?P<resource_result>.*)$
+
+[puppet-resource-node]
+REGEX = /Node\[(?P<node>[^]]+)\]/
+
+[puppet-environment]
+REGEX = environment\s+(?P<environment>[^\s:]+)
+
+[puppet-event-msg]
+REGEX = puppet-\w+\[\d+\]:\s+(?:\[cimlog[^]]+\])?\s*(?P<event_msg>.*)


### PR DESCRIPTION
Since RHEL logs puppet agent and master to /var/log/messages some fields weren't extracting, I updated props and transforms to extract fields from both sources, which seemed to work..
